### PR TITLE
Adjust RTL layout side menu

### DIFF
--- a/public/assets/css/rtl.css
+++ b/public/assets/css/rtl.css
@@ -6,3 +6,11 @@ body {
 .form-control {
     text-align: right;
 }
+
+/* RTL layout overrides */
+.leftside{left:auto;right:0;}
+.fixed-leftside .rightside{margin-left:0;margin-right:240px;}
+.sidebar-sm .rightside,
+.sidebar-sm header .navbar{margin-left:0;margin-right:80px;}
+.sidebar-sm .rightside{padding-left:0;padding-right:80px;}
+.fixed-leftside.sidebar-sm .rightside{padding-left:0;padding-right:0;}


### PR DESCRIPTION
## Summary
- fix alignment when sidebar opens from the right by adding RTL overrides

## Testing
- `npm test --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714fa5c3dc833299ca2cfeae33137d